### PR TITLE
fix(cors): Fix Storage Bucket CORS error

### DIFF
--- a/firebase/cors.json
+++ b/firebase/cors.json
@@ -1,0 +1,8 @@
+[
+  {
+    "origin": ["*"],
+    "responseHeader": ["Content-Type"],
+    "method": ["GET", "HEAD", "DELETE"],
+    "maxAgeSeconds": 3600
+  }
+]

--- a/src/containers/forms/UserForm/fields/UserFormPhotoUrlField.tsx
+++ b/src/containers/forms/UserForm/fields/UserFormPhotoUrlField.tsx
@@ -47,7 +47,9 @@ const UserFormPhotoUrlField = (props: StackProps) => {
             />
           </Stack>
           {!!errors.photoURL && (
-            <FormHelperText error>{errors.photoURL.message}</FormHelperText>
+            <FormHelperText error sx={{ textAlign: "center" }}>
+              {errors.photoURL.message}
+            </FormHelperText>
           )}
         </Stack>
       )}


### PR DESCRIPTION
This pr adds `cors.json`: a configuration to fix CORS errors on the default storage bucket.

This code does not change anything, but can be used to update CORS policies with the following command: 
```
gsutil cors set firebase/cors.json gs://ab-apps-5d45b.firebasestorage.app
```

Useful articles:
- [Firebase Storage CORS Error Resolution](https://stackoverflow.com/questions/47768136/cors-on-firebase-storage)